### PR TITLE
Hessian Prototype

### DIFF
--- a/src/EmpiricalPotentials.jl
+++ b/src/EmpiricalPotentials.jl
@@ -6,5 +6,6 @@ include("sitepotentials.jl")
 include("pairpotentials.jl")
 include("stillingerweber/stillingerweber.jl")
 
+include("site_hessians.jl")
 
 end

--- a/src/site_hessians.jl
+++ b/src/site_hessians.jl
@@ -66,11 +66,13 @@ function hessian(sys, V::SitePotential;
    Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, 1) 
    E1 = eval_site(V, Rs, Zs, z0) 
    TF = typeof(E1)
+   hU = energy_unit(V) / length_unit(V)^2
+   TFU = typeof(E1 * hU)
    # assuming here that the type of everything else will be the same?
    # need to think whether this is a restriction. 
    # also need to do something about fucking units 
 
-   H = zeros(TF, D*Nat, D*Nat)
+   H = zeros(TFU, D*Nat, D*Nat)
 
    for i in domain 
       Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, i) 
@@ -84,10 +86,10 @@ function hessian(sys, V::SitePotential;
          A2 = (α2-1) * D .+ (1:D)
          J1 = (j1-1) * D .+ (1:D)
          J2 = (j2-1) * D .+ (1:D)
-         H[J1, J2] += Hi[A1, A2]
-         H[J1, Ji] -= Hi[A1, A2]
-         H[Ji, J2] -= Hi[A1, A2]
-         H[Ji, Ji] += Hi[A1, A2]
+         H[J1, J2] += Hi[A1, A2] .* hU
+         H[J1, Ji] -= Hi[A1, A2] .* hU
+         H[Ji, J2] -= Hi[A1, A2] .* hU
+         H[Ji, Ji] += Hi[A1, A2] .* hU
       end
    end
 
@@ -115,11 +117,14 @@ function block_hessian(sys, V::SitePotential;
    Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, 1) 
    E1 = eval_site(V, Rs, Zs, z0) 
    TF = typeof(E1)
+   hU = energy_unit(V) / length_unit(V)^2
+   TFU = typeof(E1 * hU)
+
    # assuming here that the type of everything else will be the same?
    # need to think whether this is a restriction. 
    # also need to do something about fucking units 
 
-   H = zeros(SMatrix{D, D, TF}, Nat, Nat)
+   H = zeros(SMatrix{D, D, TFU}, Nat, Nat)
 
    for i in domain 
       Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, i) 
@@ -130,10 +135,10 @@ function block_hessian(sys, V::SitePotential;
       # where 𝐫_ij1 = 𝐫_j1 - 𝐫_i
       nRs = length(Js)
       for (α1, j1) in enumerate(Js), (α2, j2) in enumerate(Js)
-         H[j1, j2] += Hi[α1, α2]
-         H[j1, i] -= Hi[α1, α2]
-         H[i, j2] -= Hi[α1, α2]
-         H[i, i] += Hi[α1, α2]
+         H[j1, j2] += Hi[α1, α2] * hU
+         H[j1, i] -= Hi[α1, α2] * hU
+         H[i, j2] -= Hi[α1, α2] * hU
+         H[i, i] += Hi[α1, α2] * hU
       end
    end
 

--- a/src/site_hessians.jl
+++ b/src/site_hessians.jl
@@ -1,0 +1,142 @@
+
+"""
+Implements `hessian_site` using ForwardDiff on the site gradient. 
+This does NOT automatically implement the hessian for site potential. 
+A site potential implementation  must overload `hessian_site` e.g. as follows
+```julia
+hessian_site(V::StillingerWeber, Rs::AbstractVector{SVector{D, TF}}, Zs, z0
+                   ) where {D, TF} = ad_hessian_site(V, Rs, Zs, z0)
+```
+"""
+function ad_hessian_site(V::SitePotential, 
+                               Rs::AbstractVector{SVector{D, TF}}, 
+                               Zs, z0) where {D, TF}
+   Rs2x = Rs -> reinterpret(eltype(eltype(Rs)), Rs)
+   x2Rs = x -> reinterpret(SVector{D, eltype(x)}, x)
+   # f = gradient in x coordinates 
+   f = x -> Rs2x( eval_grad_site(V, x2Rs(x), Zs, z0)[2] ) 
+   # ∂f = jacobian of f so i.e. the hessian of site energy in x coords
+   ∂f = ForwardDiff.jacobian(f, Rs2x(Rs))
+   return ∂f
+end
+
+
+"""
+Implements `block_hessian_site` using ForwardDiff on the site gradient. 
+This does NOT automatically implemet the hessian. A site potential implementation 
+must overload `block_hessian_site` e.g. as follows
+```julia
+block_hessian_site(V::StillingerWeber, Rs::AbstractVector{SVector{D, TF}}, Zs, z0
+                   ) where {D, TF} = ad_block_hessian_site(V, Rs, Zs, z0)
+```
+"""
+function ad_block_hessian_site(V::SitePotential, 
+                               Rs::AbstractVector{SVector{D, TF}}, 
+                               Zs, z0) where {D, TF}
+   ∂f = ad_hessian_site(V, Rs, Zs, z0)                               
+   # convert to smatrix blocks 
+   nR = length(Rs)
+   Hblock = zeros(SMatrix{D, D, TF}, nR, nR)
+   for j1 = 1:nR, j2 = 1:nR 
+      J1 = 3 * (j1-1) .+ (1:3)
+      J2 = 3 * (j2-1) .+ (1:3)
+      Hblock[j1, j2] = SMatrix{D, D}(∂f[J1, J2])
+   end
+   return Hblock 
+end
+
+
+# ------------------------------------------------ 
+#   global hessian assembly prototypes 
+
+function hessian(sys, V::SitePotential; 
+                       domain=1:length(sys), 
+                       executor=ThreadedEx(), 
+                       nlist=nothing, 
+                       kwargs...
+                       )
+   if isnothing(nlist)
+      nlist = PairList(sys, cutoff_radius(V))
+   end
+
+   Nat = length(sys)
+   D = n_dimensions(sys)
+
+   # learn what the types are 
+   Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, 1) 
+   E1 = eval_site(V, Rs, Zs, z0) 
+   TF = typeof(E1)
+   # assuming here that the type of everything else will be the same?
+   # need to think whether this is a restriction. 
+   # also need to do something about fucking units 
+
+   H = zeros(TF, D*Nat, D*Nat)
+
+   for i in domain 
+      Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, i) 
+      Hi = hessian_site(V, Rs, Zs, z0)
+      release!(Js); release!(Rs); release!(Zs)
+
+      Nr = length(Js)
+      Ji = (i - 1) * D .+ (1:D)
+      for (α1, j1) in enumerate(Js), (α2, j2) in enumerate(Js)
+         A1 = (α1-1) * D .+ (1:D)
+         A2 = (α2-1) * D .+ (1:D)
+         J1 = (j1-1) * D .+ (1:D)
+         J2 = (j2-1) * D .+ (1:D)
+         H[J1, J2] += Hi[A1, A2]
+         H[J1, Ji] -= Hi[A1, A2]
+         H[Ji, J2] -= Hi[A1, A2]
+         H[Ji, Ji] += Hi[A1, A2]
+      end
+   end
+
+   return H
+end
+
+
+
+
+
+function block_hessian(sys, V::SitePotential; 
+                       domain=1:length(sys), 
+                       executor=ThreadedEx(), 
+                       nlist=nothing, 
+                       kwargs...
+                       )
+   if isnothing(nlist)
+      nlist = PairList(sys, cutoff_radius(V))
+   end
+
+   Nat = length(sys)
+   D = n_dimensions(sys)
+
+   # learn what the types are 
+   Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, 1) 
+   E1 = eval_site(V, Rs, Zs, z0) 
+   TF = typeof(E1)
+   # assuming here that the type of everything else will be the same?
+   # need to think whether this is a restriction. 
+   # also need to do something about fucking units 
+
+   H = zeros(SMatrix{D, D, TF}, Nat, Nat)
+
+   for i in domain 
+      Js, Rs, Zs, z0 = get_neighbours(sys, V, nlist, i) 
+      Hi = block_hessian_site(V, Rs, Zs, z0)
+      release!(Js); release!(Rs); release!(Zs)
+
+      # Hi[j1, j2] = ∂²V/∂𝐫_ij1 ∂𝐫_ij2
+      # where 𝐫_ij1 = 𝐫_j1 - 𝐫_i
+      nRs = length(Js)
+      for (α1, j1) in enumerate(Js), (α2, j2) in enumerate(Js)
+         H[j1, j2] += Hi[α1, α2]
+         H[j1, i] -= Hi[α1, α2]
+         H[i, j2] -= Hi[α1, α2]
+         H[i, i] += Hi[α1, α2]
+      end
+   end
+
+   return H
+end
+

--- a/src/sitepotentials.jl
+++ b/src/sitepotentials.jl
@@ -63,31 +63,16 @@ The output `Pblock` should be an `AbstractMatrix` containing
 Unlike `eval_site` and `eval_grad_site`, this method is optional. It 
 can be used to speedup geometry optimization, sampling and related tasks. 
 """
+function block_precon end 
+
 function precon end 
 
+function block_hessian_site end 
 
-# This is an attempt at a general hessian implementation 
-# It does not work, because ForwardDiff seems to not play well 
-# with SVector. It is missing a number of methods. Strange. 
-function ad_site_hessian(V::SitePotential, Rs::AbstractVector{SVector{D, TF}}, 
-                         Zs, z0) where {D, TF}
-   Rs2x = Rs -> reinterpret(eltype(eltype(Rs)), Rs)
-   x2Rs = x -> reinterpret(SVector{D, eltype(x)}, x)
-   # f = gradient in x coordinates 
-   f = x -> Rs2x( eval_grad_site(V, x2Rs(x), Zs, z0)[2] ) 
-   # ∂f = jacobian of f so i.e. the hessian of site energy in x coords
-   ∂f = ForwardDiff.jacobian(f, Rs2x(Rs))
-   # convert to smatrix blocks 
-   nR = length(Rs)
-   Hblock = zeros(SMatrix{D, D, TF}, nR, nR)
-   for j1 = 1:nR, j2 = 1:nR 
-      J1 = 3 * (j1-1) .+ (1:3)
-      J2 = 3 * (j2-1) .+ (1:3)
-      Hblock[j1, j2] = SMatrix{D, D}(∂f[J1, J2])
-   end
-   return Hblock 
-end
+function hessian_site end 
 
+
+# ---------------------------
 
 
 # Used to define ouput type and unit.

--- a/src/stillingerweber/stillingerweber.jl
+++ b/src/stillingerweber/stillingerweber.jl
@@ -246,6 +246,19 @@ function eval_grad_site(calc::StillingerWeber, Rs, Zs, z0)
 end
 
 
+# ---------------------------------------------------
+# the hessian implementation just uses the ForwardDiff fallbacks 
+
+block_hessian_site(sw::StillingerWeber, args...) = 
+         ad_block_hessian_site(sw, args...)
+
+
+hessian_site(sw::StillingerWeber, args...) = 
+         ad_hessian_site(sw, args...)
+
+
+# ---------------------------------------------------
+#  the preconditioner implementation
 
 
 # ∇V  = V'(r) 𝐫̂ 

--- a/src/stillingerweber/stillingerweber.jl
+++ b/src/stillingerweber/stillingerweber.jl
@@ -87,6 +87,10 @@ struct StillingerWeber{P1, P2, T, TI} <: SitePotential
    atomic_id::TI
 end
 
+energy_unit(calc::StillingerWeber) = u"eV"
+length_unit(calc::StillingerWeber) = u"Å"
+force_unit(calc::StillingerWeber) = u"eV/Å"
+
 cutoff_radius(calc::StillingerWeber) = calc.rcut * u"Å"
 
 function StillingerWeber(;

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 AtomsCalculators = "a3e0e189-c65a-42c1-833c-339540406eb1"
+EmpiricalPotentials = "38527215-9240-4c91-a638-d4250620c9e2"
 ExtXYZ = "352459e4-ddd7-4360-8937-99dcb397b478"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/test/test_adhess.jl
+++ b/test/test_adhess.jl
@@ -69,7 +69,7 @@ for ntest = 1:10
    F(t) = - dot(forces(_sys(X0 + t * Us), sw), Vs) 
    F(0.0)
    H0 = EP.block_hessian(_sys(X0), sw)
-   dF0 = dot(H0 * ustrip.(Us), ustrip.(Vs))
+   dF0 = dot(H0 * Us, Vs)
    @test ACT.fdtest(F, t -> dF0, 0.0; verbose = false )
 end
 

--- a/test/test_adhess.jl
+++ b/test/test_adhess.jl
@@ -1,0 +1,50 @@
+
+
+using AtomsBase, Unitful, ExtXYZ, AtomsCalculators, AtomsBuilder,
+      EmpiricalPotentials, StaticArrays, Test, JSON, ForwardDiff 
+using AtomsCalculators.AtomsCalculatorsTesting
+using LinearAlgebra: dot, norm, I 
+using EmpiricalPotentials: cutoff_radius, StillingerWeber
+using AtomsCalculators: potential_energy, forces
+
+EP = EmpiricalPotentials
+ACT = AtomsCalculators.AtomsCalculatorsTesting
+
+sw = StillingerWeber()
+
+function rand_Si_struct(nrep = 2, r = 0.1) 
+   rattle!(bulk(:Si, cubic=true), r)   
+end
+
+function rand_Si_env(args...)
+   sys = rand_Si_struct(args...)
+   nlist = EmpiricalPotentials.PairList(sys, cutoff_radius(StillingerWeber()))
+   Js, Rs, Zs, z0 = EmpiricalPotentials.get_neighbours(sys, sw, nlist, 1)
+   return Rs, Zs, z0 
+end
+
+##
+
+# preliminary finit-difference test, this is to be incorporated into the 
+# FD tests in the test suite in AtomsCalculators
+
+for ntest = 1:10 
+   Rs, Zs, z0 = rand_Si_env()
+   Us = randn(eltype(Rs), length(Rs))
+   Vs = randn(eltype(Rs), length(Rs))
+   F(t) = dot( EP.eval_grad_site(sw, Rs + t * Us, Zs, z0)[2], Vs )
+   dF0 = dot( EP.ad_site_hessian(sw, Rs, Zs, z0) * Us, Vs )
+
+   @test ACT.fdtest(F, t -> dF0, 0.0; verbose = false )
+end
+
+##
+
+using BenchmarkTools
+
+Rs, Zs, z0 = rand_Si_env()
+
+@info("Timing of eval_grad_site")
+@btime EP.eval_grad_site($sw, $Rs, $Zs, $z0)
+@info("Timing of ad_site_hessian")
+@btime EP.ad_site_hessian($sw, $Rs, $Zs, $z0)

--- a/test/test_adhess.jl
+++ b/test/test_adhess.jl
@@ -33,18 +33,69 @@ for ntest = 1:10
    Us = randn(eltype(Rs), length(Rs))
    Vs = randn(eltype(Rs), length(Rs))
    F(t) = dot( EP.eval_grad_site(sw, Rs + t * Us, Zs, z0)[2], Vs )
-   dF0 = dot( EP.ad_site_hessian(sw, Rs, Zs, z0) * Us, Vs )
+   dF0 = dot( EP.ad_block_hessian_site(sw, Rs, Zs, z0) * Us, Vs )
 
    @test ACT.fdtest(F, t -> dF0, 0.0; verbose = false )
 end
 
 ##
+# a quick test that shows the ForwardDiff implementation is quite decent.
+# using BenchmarkTools
+# Rs, Zs, z0 = rand_Si_env()
+# @info("Timing of eval_grad_site")
+# @btime EP.eval_grad_site($sw, $Rs, $Zs, $z0)
+# @info("Timing of ad_site_hessian")
+# @btime EP.ad_site_hessian($sw, $Rs, $Zs, $z0)
 
-using BenchmarkTools
+## 
+# look at the global hessian now 
+# first in block format 
 
-Rs, Zs, z0 = rand_Si_env()
+for ntest = 1:10 
+   sys = rand_Si_struct()
+   H = EP.block_hessian(sys, sw)
 
-@info("Timing of eval_grad_site")
-@btime EP.eval_grad_site($sw, $Rs, $Zs, $z0)
-@info("Timing of ad_site_hessian")
-@btime EP.ad_site_hessian($sw, $Rs, $Zs, $z0)
+   X0 = position(sys)
+   uL = unit(X0[1][1])
+   Us = randn(SVector{3, Float64}, length(X0)) * uL 
+   Vs = randn(SVector{3, Float64}, length(X0)) * uL / u"eV" 
+   _sys(X) = FastSystem(bounding_box(sys), 
+                        boundary_conditions(sys), 
+                        X, 
+                        atomic_symbol(sys), 
+                        atomic_number(sys), 
+                        atomic_mass(sys))
+
+   F(t) = - dot(forces(_sys(X0 + t * Us), sw), Vs) 
+   F(0.0)
+   H0 = EP.block_hessian(_sys(X0), sw)
+   dF0 = dot(H0 * ustrip.(Us), ustrip.(Vs))
+   @test ACT.fdtest(F, t -> dF0, 0.0; verbose = false )
+end
+
+##
+# now global hessian in blas format 
+
+function _globify(Abl::AbstractMatrix{SMatrix{D, D, T}}) where {D, T} 
+   A = zeros(T, D * size(Abl, 1), D * size(Abl, 2))
+   for j1 = 1:size(Abl, 1), j2 = 1:size(Abl, 2) 
+      J1 = D * (j1-1) .+ (1:D)
+      J2 = D * (j2-1) .+ (1:D)
+      A[J1, J2] .= Abl[j1, j2]
+   end
+   return A 
+end
+
+for ntest = 1:10 
+   Rs, Zs, z0 = rand_Si_env()
+   Hi = EP.hessian_site(sw, Rs, Zs, z0)
+   Hi_bl = EP.block_hessian_site(sw, Rs, Zs, z0)
+   @test Hi ≈ _globify(Hi_bl)
+end
+
+for ntest = 1:10 
+   sys = rand_Si_struct()
+   H = EP.hessian(sys, sw)
+   Hbl = EP.block_hessian(sys, sw)
+   @test H ≈ _globify(Hbl)
+end


### PR DESCRIPTION
This PR is to provide a prototype hessian implementation. This is needed for a different project, so I can't wait around anymore until the community decides on the AtomsCalculators format. 

Needs the FD PR in AtomsCalculators to be merged first.

- [x] fix `ad_site_hessian` 
- [x] tests for site hessian (prototype)
- [x] implement global hessian assembly, both block-format and blas format
- [x] test global hessian assembly 
- [x] sort out units 

### Comments

- This PR also changes the SW implementation slightly. SW now simply fails if the input structure is not elemental Si. We can debate this and I can reverse this change if I see a good reason. Personally, I don't see how SW can ever be used for anything other than elemental Si 
- The hessian currently returns a dense format. This is obviously not ideal. I think of this implementation only as a prototype to be improved upon in a few more PRs.